### PR TITLE
Respawn epuck_driver node in case the connection fails

### DIFF
--- a/launch/epuck_controller.launch
+++ b/launch/epuck_controller.launch
@@ -16,7 +16,7 @@
 	<arg name="theta" default="0.0"/>
 	<arg name="is_single_robot" default="1" />
 
-    <node pkg="epuck_driver" type="epuck_driver.py" name="$(arg epuck_name)" output="screen">
+    <node pkg="epuck_driver" type="epuck_driver.py" name="$(arg epuck_name)" output="screen" respawn="true">
         <param name="epuck_address" value="$(arg epuck_address)"/>
         <param name="epuck_name" value="$(arg epuck_name)"/>
         <param name="camera" value="$(arg cam_en)"/>


### PR DESCRIPTION
The ``epuck_driver`` node is respawned in case it fails and the associated process dies.